### PR TITLE
Modify SVG element on resize instead of appending new element

### DIFF
--- a/src/htmlwidget/inst/htmlwidgets/topicBubbles.js
+++ b/src/htmlwidget/inst/htmlwidgets/topicBubbles.js
@@ -133,8 +133,10 @@ HTMLWidgets.widget({
         self.g = d3.select("#root-node")
             .attr("transform", "translate(" + SVG_R + "," + SVG_R + ")");
 
-        // Re-render according to new dimensions
-        self.updateView(false);
+        // Re-render according to new dimensions, only if data already rendered
+        if (self.treeData !== null) {
+            self.updateView(false);
+        }
     },
 
     renderValue: function (el, rawData) {


### PR DESCRIPTION
Upon resize event, the html widget now selects the existing SVG element and modifies that element's attributes. There is some delay upon resize, but it doesn't seem longer than delays for any other events (on my macbook, on Chrome). Tested when loading the file both before and after resize events.