### PR TITLE
Add styling to hide hidden input

### DIFF
--- a/src/shiny/www/styling.css
+++ b/src/shiny/www/styling.css
@@ -13,3 +13,7 @@ h2 {
 #hover {
   display: none;
 }
+
+#active {
+	visibility: hidden;
+}


### PR DESCRIPTION
Fix for Issue #27 
Simple fix. Input was never hidden before, just drawn under the SVG background.