### PR TITLE
Cluster bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .Rhistory
 rsconnect/
+.DS_Store

--- a/src/shiny/server.R
+++ b/src/shiny/server.R
@@ -85,7 +85,7 @@ function(input, output, session) {
     #      However, the length of assignments in input$topics will
     #      correspond to the previous num.clusters, resulting in a
     #      crash unless we verify before returning here.
-    if (length(ids) != input$num.clusters) {
+    if (length(ids) != (K() + input$num.clusters)) {
       return(c(fit$cluster + K(), rep(0, input$num.clusters)))
     }
 
@@ -150,14 +150,11 @@ function(input, output, session) {
     if (is.null(data()))
       return(NULL)
 
-
-    pid <- c(rep(0, input$num.clusters), kmeans.fit()$cluster + K())
-    nid <- c(seq(K()+1,K()+input$num.clusters), seq(K()))
-    wgt <- c(rep(0, input$num.clusters), colSums(data()$model$theta))
-    ttl <- c(isolate(cluster.titles()), titles())
-
-    rv <- data.frame(parentID=pid, nodeID=nid, weight=wgt, title=ttl)
-
+    #parent.id, topic.id, weight, title
+    rv <- data.frame(parentID=c(rep(0, input$num.clusters), kmeans.fit()$cluster + K()),
+                     nodeID=c(seq(K()+1,K()+input$num.clusters), seq(K())),
+                     weight=c(rep(0, input$num.clusters), colSums(data()$model$theta)),
+                     title=c(isolate(cluster.titles()), titles()))
 
     return(rv)
   })

--- a/src/shiny/server.R
+++ b/src/shiny/server.R
@@ -95,6 +95,8 @@ function(input, output, session) {
     if (is.null(data()))
       return(c())
 
+    print("Running cluster titles!!!!")
+
     marginals <- matrix(0, nrow=n.nodes(), ncol=ncol(beta()))
     weights <- colSums(data()$model$theta)
     for (node in seq(length(assignments()), 1)) {
@@ -138,11 +140,22 @@ function(input, output, session) {
     if (is.null(data()))
       return(NULL)
 
+    print("A")
+
+    pid <- c(rep(0, input$num.clusters), kmeans.fit()$cluster + K())
+    nid <- c(seq(K()+1,K()+input$num.clusters), seq(K()))
+    wgt <- c(rep(0, input$num.clusters), colSums(data()$model$theta))
+    ttl <- c(isolate(cluster.titles()), titles())
+
     #parent.id, topic.id, weight, title
-    rv <- data.frame(parentID=c(rep(0, input$num.clusters), kmeans.fit()$cluster + K()),
-                     nodeID=c(seq(K()+1,K()+input$num.clusters), seq(K())),
-                     weight=c(rep(0, input$num.clusters), colSums(data()$model$theta)),
-                     title=c(isolate(cluster.titles()), titles()))
+    # rv <- data.frame(parentID=c(rep(0, input$num.clusters), kmeans.fit()$cluster + K()),
+    #                  nodeID=c(seq(K()+1,K()+input$num.clusters), seq(K())),
+    #                  weight=c(rep(0, input$num.clusters), colSums(data()$model$theta)),
+    #                  title=c(isolate(cluster.titles()), titles()))
+
+    rv <- data.frame(parentID=pid, nodeID=nid, weight=wgt, title=ttl)
+
+    print("B")
 
     return(rv)
   })

--- a/src/shiny/server.R
+++ b/src/shiny/server.R
@@ -26,18 +26,21 @@ function(input, output, session) {
   })
 
   kmeans.fit <- reactive({
+    print("kmeansfit")
     if (is.null(beta()))
       return(NULL)
     return(kmeans(beta(), input$num.clusters))
   })
 
   K <- reactive({
+    print("k")
     if (is.null(data()))
       return(0)
     return(nrow(beta()))
   })
 
   titles <- reactive({
+    print("titles")
     rv <- c()
     if (is.null(data()))
       return(rv)
@@ -51,12 +54,20 @@ function(input, output, session) {
   })
 
   assignments <- reactive({
+    print("assignments")
     if (is.null(data()))
       return(c())
 
-    if (input$topics == "")
-      return(c(kmeans.fit()$cluster + K(), rep(0, input$num.clusters)))
+    fit <- kmeans.fit()
+    nclusters <- input$num.clusters
+    print("babba:")
+    print(nclusters)
 
+    if (input$topics == "")
+      print("cheeeep!!")
+      return(c(fit$cluster + K(), rep(0, nclusters)))
+
+    print("Dunk :(")
     node.ids <- c()
     parent.ids <- c()
     for (pair in strsplit(input$topics, ',')[[1]]) {
@@ -81,6 +92,7 @@ function(input, output, session) {
   })
 
   n.nodes <- reactive({
+    print("nnodes")
     if (is.null(data()))
       return(0)
 
@@ -92,10 +104,9 @@ function(input, output, session) {
 
   # TODO: this may not work for deeper hierarchy; needs to be checked once implemented
   cluster.titles <- reactive({
+    print("clustertitles")
     if (is.null(data()))
       return(c())
-
-    print("Running cluster titles!!!!")
 
     marginals <- matrix(0, nrow=n.nodes(), ncol=ncol(beta()))
     weights <- colSums(data()$model$theta)
@@ -109,6 +120,8 @@ function(input, output, session) {
         val <- marginals[node - K(),]
       marginals[assignments()[node]-K(),] <- marginals[assignments()[node]-K(),] + val
     }
+    print("yo:")
+    print(n.nodes())
 
     rv <- c()
     for (cluster in seq(n.nodes())) {


### PR DESCRIPTION
BUG: "Cluster bug" occurred when changing the number of clusters after manually reassigning nodes to new bubbles. The underlying cause appears to have been input$topics. When a node is manually set, input$topics is updated with a list of all new assignments. When updating assignments on the backend/server-side, the R code preferentially parses existing input$topics assignments over generating new ones. This would lead to an inaccurate number of assignments (as the total number of clusters would correspond to the assignments set under a previous num.clusters).

SOLUTION: Before returning assignments (as a reactive variable), there is now a check to ensure that the number of assignments is appropriate for the number of clusters. If not, assignments are re-generated from scratch (as we have re-clustered the data).